### PR TITLE
[29기 석정도] 전역폰트 설정

### DIFF
--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -6,6 +6,10 @@ const GlobalStyle = createGlobalStyle`
   * {
     box-sizing: border-box;
   }
+
+  body {
+    font-family: 'SF Pro Display', sans-serif;
+  }
   
 `;
 export default GlobalStyle;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 전역폰트 설정

<br />

## :: 구현 사항 설명 
1. 웹에서 동일한 폰트를 사용하기 때문에 전역으로 설정하기로 했습니다.

<br />

## :: 성장 포인트 

<br />

## :: 기타 질문 및 특이 사항
- 개발자 도구로 확인했을 때 적용이 된 것 처럼 보이는데 세로선이 그어지는 이유가 뭔지 알 수 있을까요? 해당 엘리먼트를 마우스로 확인하면 적용이 되었다고 표시가 되는데 style 탭에서 확인했을 때는 가로선이 그어져 있습니다.
