### PR TITLE
이메일 로그인

### DIFF
--- a/src/pages/Members/SignComponents/Button.js
+++ b/src/pages/Members/SignComponents/Button.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 export default function Button(props) {
-  const { isValidate, clickLoginButton } = props;
+  const { title, isValidate, clickLoginButton } = props;
   const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?&client_id=${process.env.REACT_APP_REST_API_KEY}&redirect_uri=${process.env.REACT_APP_REDIRECT_URI}&response_type=code`;
 
   return (
@@ -10,7 +10,7 @@ export default function Button(props) {
       <div className="Button">
         <ButtonWrap>
           <SignUpButton disabled={!isValidate} onClick={clickLoginButton}>
-            동의하고 가입하기
+            {title === '로그인' ? '로그인하기' : '동의하고 가입하기'}
           </SignUpButton>
         </ButtonWrap>
       </div>

--- a/src/pages/Members/SignComponents/LoginForm.js
+++ b/src/pages/Members/SignComponents/LoginForm.js
@@ -81,7 +81,11 @@ const LoginForm = props => {
             handleInput={handleInput}
           />
         ))}
-        <Button isValidate={isValidate} clickLoginButton={clickLoginButton} />
+        <Button
+          title={title}
+          isValidate={isValidate}
+          clickLoginButton={clickLoginButton}
+        />
       </FormLayout>
     </LoginBody>
   );


### PR DESCRIPTION
- 레이아웃 회원가입 컴포넌트 재활용
- 카카오 버튼 추가
- 조건 일치/불일치시 alert창 띄우기
- 카카오 버튼 클릭시 카카오로 로그인하기 활성화
- 로그인 조건 만족시 버튼 활성화
- 버튼 내용 2가지로 변경

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 아이디, 비밀번호 입력창을 사용한 로그인 기능 구현 (예시)

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 로그인 입력 데이터 유효성 검사 (예시 - 프론트)
- 입력창에 변화가 일어날 때 마다 유효성 검사 함수가 실행된다.
- 유효성 검사 함수의 반환값(boolean)에 따라 버튼의 배경색과 disabled 속성이 변화한다.
- 테스트 방법 : `/login` 페이지 이동 >>> 로그인 input 데이터 입력

2. 로그인 데이터 처리 (예시 - 백엔드)
- 조건문과 정규식을 이용한 email과 password 유효성 검사를 진행
- 유효섬 검사를 통과하지 못 할 경우 에러 메시지를 반환 예외 처리 구현

<br />

## :: 성장 포인트 

<br />

